### PR TITLE
feat: enable header link to home

### DIFF
--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -1,5 +1,6 @@
 import { Settings, Moon } from 'lucide-react';
 import { useState, useEffect } from 'react';
+import { Link } from 'wouter';
 import { Button } from '@/components/ui/button';
 
 export function Header() {
@@ -20,14 +21,17 @@ export function Header() {
   return (
     <header className="bg-card/90 border-b border-border sticky top-0 z-50 backdrop-blur-sm" data-testid="header-main">
       <div className="max-w-md mx-auto px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center space-x-3">
+        <Link
+          href="/"
+          className="flex items-center space-x-3 rounded-lg text-foreground no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
           <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
             <svg className="w-4 h-4 text-primary-foreground" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
             </svg>
           </div>
           <h1 className="text-lg font-semibold" data-testid="text-app-title">FitTimer Pro</h1>
-        </div>
+        </Link>
         <div className="flex items-center space-x-2">
           {/* <Button 
             variant="ghost" 


### PR DESCRIPTION
## Summary
- wrap the header icon and title in a wouter Link so clicking them returns to the welcome page
- preserve styling while adding focus-visible treatment for keyboard navigation

## Testing
- npm run check *(fails: server/storage.ts references session.SessionStore which no longer exists)*

------
https://chatgpt.com/codex/tasks/task_e_68d18f346e848327b6d4b429e7284595